### PR TITLE
feat(logging): M1-D1 unified get_logger + smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added schema field documentation (`docs/schema_v0.md`).
 - Added good/bad example JSON files.
 - Added pytest schema validation tests.
+## [0.1.0-dev] - Logging baseline (M1-D1)
+- Added project-wide `get_logger()` helper with unified format.
+- Added logging smoke tests to ensure handler reuse and formatter expectations.
 ## [Unreleased]
 - M1-C1 完成：schema 装载与缓存接口（load_schema/validate/list_schemas/clear_caches，支持 AC_SCHEMA_DIR 覆盖，缓存命中测试通过）
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ mfusion_doc = load_mfusion_input("tests/examples/Vec_Z2_mfusion.json")
 write_umtc_output("tmp/umtc_output.json", mfusion_doc)
 PY
 ```
+
+## Logging
+
+Use the bundled logger to produce consistent output:
+
+```python
+from anyon_condense.core.logging import get_logger
+
+log = get_logger(__name__, level="INFO")
+log.info("pipeline ready")
+```
+
+The default format is `ts | level | module | message`; adjust the level per caller when needed.

--- a/anyon_condense/core/logging.py
+++ b/anyon_condense/core/logging.py
@@ -1,48 +1,46 @@
-"""Project-wide logging helpers."""
+"""Project-wide logging helpers with unified formatting."""
 
 from __future__ import annotations
 
 import logging
-import os
 from typing import Optional
 
 _INITIALIZED = False
+_FMT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
 
 
 def _resolve_level(level: Optional[str]) -> int:
-    if level is not None:
-        return getattr(logging, level.upper(), logging.INFO)
-    level_name = os.environ.get("AC_LOG_LEVEL", "INFO").upper()
-    return getattr(logging, level_name, logging.INFO)
+    if isinstance(level, str):
+        name = level.upper()
+        return getattr(logging, name, logging.INFO)
+    return logging.INFO
 
 
-def init_logging(level: Optional[str] = None) -> None:
-    """Initialise root logger once with consistent formatting."""
+def get_logger(name: str, level: str = "INFO") -> logging.Logger:
+    """Return a logger configured with the project's default handler/format."""
 
     global _INITIALIZED
-    if _INITIALIZED:
-        return
 
-    resolved_level = _resolve_level(level)
-    root_logger = logging.getLogger()
-    root_logger.setLevel(resolved_level)
+    root = logging.getLogger()
+    if not _INITIALIZED:
+        desired_level = _resolve_level(level)
 
-    handler = logging.StreamHandler()
-    handler.setLevel(resolved_level)
-    formatter = logging.Formatter(
-        "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
-    )
-    handler.setFormatter(formatter)
-    root_logger.addHandler(handler)
+        handler = next(
+            (h for h in root.handlers if getattr(h, "_ac_default", False)),
+            None,
+        )
+        if handler is None:
+            handler = logging.StreamHandler()
+            handler._ac_default = True  # type: ignore[attr-defined]
+            root.addHandler(handler)
 
-    _INITIALIZED = True
+        handler.setLevel(desired_level)
+        handler.setFormatter(logging.Formatter(_FMT))
+        root.setLevel(desired_level)
 
+        _INITIALIZED = True
 
-def get_logger(name: str) -> logging.Logger:
-    """Return a logger configured with project defaults."""
-
-    init_logging()
     return logging.getLogger(name)
 
 
-__all__ = ["get_logger", "init_logging"]
+__all__ = ["get_logger"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,15 @@ Homepage = "https://example.com"
 [project.scripts]
 ac = "anyon_condense.__main__:main"
 
-[project.optional-dependencies]
-dev = ["pytest", "mypy", "ruff", "pre-commit"]
-
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["anyon_condense*"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"

--- a/tests/unit/test_logging_smoke.py
+++ b/tests/unit/test_logging_smoke.py
@@ -1,0 +1,40 @@
+import logging
+
+from anyon_condense.core.logging import get_logger
+
+
+def test_get_logger_writes_to_caplog(caplog):
+    caplog.set_level(logging.INFO)
+    logger = get_logger("test.logger", level="INFO")
+    logger.info("hello-world")
+
+    assert any(
+        record.levelname == "INFO"
+        and record.name == "test.logger"
+        and "hello-world" in record.message
+        for record in caplog.records
+    )
+
+
+def test_logger_format_and_single_handler():
+    get_logger("a.b.c", level="DEBUG")
+    root = logging.getLogger()
+
+    ac_handlers = [
+        handler for handler in root.handlers if getattr(handler, "_ac_default", False)
+    ]
+    assert len(ac_handlers) == 1
+
+    formatter = ac_handlers[0].formatter
+    assert formatter is not None
+    fmt = formatter._fmt  # type: ignore[attr-defined]
+    assert "%(asctime)s" in fmt
+    assert "%(levelname)s" in fmt
+    assert "%(name)s" in fmt
+    assert "%(message)s" in fmt
+
+    get_logger("x.y.z", level="ERROR")
+    ac_handlers_again = [
+        handler for handler in root.handlers if getattr(handler, "_ac_default", False)
+    ]
+    assert len(ac_handlers_again) == 1


### PR DESCRIPTION
What’s changed

Introduce core/logging.get_logger(name, level="INFO")

Unified format: ts | level | module | msg

Add tests/unit/test_logging_smoke.py (caplog)

Minor docs/CHANGELOG updates

Why

Provide consistent logging across CLI/pipelines

Make CI/debugging easier; foundation for C3 error logging

Checks

 pip install -e .

 pytest -q green

 pre-commit run -a green

Notes

No runtime behavior change outside logging usage

No external deps added