### PR TITLE
[M2-C1] Integrate NumericPolicy into consistency checks

### DIFF
--- a/anyon_condense/core/consistency/__init__.py
+++ b/anyon_condense/core/consistency/__init__.py
@@ -1,0 +1,21 @@
+"""Consistency checks built on NumericPolicy-aware comparisons."""
+
+from .hexagon import check_hexagon_equations
+from .modular import check_modular_relations
+from .numcheck import (
+    approx_equal_matrices,
+    approx_equal_number,
+    approx_equal_vectors,
+    max_abs_diff,
+)
+from .pentagon import check_pentagon_equations
+
+__all__ = [
+    "approx_equal_matrices",
+    "approx_equal_number",
+    "approx_equal_vectors",
+    "check_hexagon_equations",
+    "check_modular_relations",
+    "check_pentagon_equations",
+    "max_abs_diff",
+]

--- a/anyon_condense/core/consistency/hexagon.py
+++ b/anyon_condense/core/consistency/hexagon.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Tuple, Union
+
+from anyon_condense.core.consistency.numcheck import approx_equal_number
+from anyon_condense.scalars.numeric_policy import NumericPolicy
+
+Number = Union[int, float, complex]
+
+
+def check_hexagon_equations(
+    equations: Iterable[Tuple[Number, Number]], policy: NumericPolicy
+) -> Dict[str, Any]:
+    total = 0
+    failed = 0
+    for lhs, rhs in equations:
+        total += 1
+        if not approx_equal_number(lhs, rhs, policy):
+            failed += 1
+    return {"status": failed == 0, "failed": failed, "total": total}

--- a/anyon_condense/core/consistency/modular.py
+++ b/anyon_condense/core/consistency/modular.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import List, Sequence, Union
+
+from anyon_condense.core.consistency.numcheck import (
+    approx_equal_matrices,
+    max_abs_diff,
+)
+from anyon_condense.scalars.numeric_policy import NumericPolicy
+
+Number = Union[int, float, complex]
+
+
+def _eye(n: int) -> List[List[complex]]:
+    return [[1.0 + 0.0j if i == j else 0.0 + 0.0j for j in range(n)] for i in range(n)]
+
+
+def _matmul(
+    a: Sequence[Sequence[complex]], b: Sequence[Sequence[complex]]
+) -> List[List[complex]]:
+    rows, inner, cols = len(a), len(a[0]), len(b[0])
+    result = [[0.0 + 0.0j for _ in range(cols)] for __ in range(rows)]
+    for i in range(rows):
+        for k in range(inner):
+            aik = a[i][k]
+            if aik == 0:
+                continue
+            for j in range(cols):
+                result[i][j] += aik * b[k][j]
+    return result
+
+
+def _matpow(a: Sequence[Sequence[complex]], power: int) -> List[List[complex]]:
+    if power == 0:
+        return _eye(len(a))
+    acc: List[List[complex]] = _eye(len(a))
+    base: List[List[complex]] = [list(row) for row in a]
+    exp = power
+    while exp > 0:
+        if exp & 1:
+            acc = _matmul(acc, base)
+        base = _matmul(base, base)
+        exp >>= 1
+    return acc
+
+
+def check_modular_relations(
+    s_matrix: Sequence[Sequence[Number]],
+    t_matrix: Sequence[Sequence[Number]],
+    policy: NumericPolicy,
+) -> dict[str, Union[bool, float]]:
+    """Check modular identities using approximate comparisons."""
+
+    s_complex = [[complex(entry) for entry in row] for row in s_matrix]
+    t_complex = [[complex(entry) for entry in row] for row in t_matrix]
+
+    identity = _eye(len(s_complex))
+    st = _matmul(s_complex, t_complex)
+    st_cubed = _matpow(st, 3)
+    s_squared = _matpow(s_complex, 2)
+    s_fourth = _matpow(s_complex, 4)
+
+    ok_st3_eq_s2 = approx_equal_matrices(st_cubed, s_squared, policy)
+    ok_s4_eq_i = approx_equal_matrices(s_fourth, identity, policy)
+
+    return {
+        "status": bool(ok_st3_eq_s2 and ok_s4_eq_i),
+        "max_err_st3_s2": max_abs_diff(st_cubed, s_squared),
+        "max_err_s4_i": max_abs_diff(s_fourth, identity),
+    }

--- a/anyon_condense/core/consistency/numcheck.py
+++ b/anyon_condense/core/consistency/numcheck.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from anyon_condense.scalars.numeric_policy import NumericPolicy, approx_equal
+
+Number = Union[int, float, complex]
+
+__all__ = [
+    "approx_equal_number",
+    "approx_equal_vectors",
+    "approx_equal_matrices",
+    "max_abs_diff",
+]
+
+
+def approx_equal_number(a: Number, b: Number, policy: NumericPolicy) -> bool:
+    """Return True when two scalars are approximately equal under the policy."""
+
+    if isinstance(a, complex) or isinstance(b, complex):
+        ar, ai = (a.real, a.imag) if isinstance(a, complex) else (float(a), 0.0)
+        br, bi = (b.real, b.imag) if isinstance(b, complex) else (float(b), 0.0)
+        return approx_equal(ar, br, policy) and approx_equal(ai, bi, policy)
+    return approx_equal(float(a), float(b), policy)
+
+
+def approx_equal_vectors(
+    u: Sequence[Number], v: Sequence[Number], policy: NumericPolicy
+) -> bool:
+    if len(u) != len(v):
+        return False
+    for x, y in zip(u, v):
+        if not approx_equal_number(x, y, policy):
+            return False
+    return True
+
+
+def approx_equal_matrices(
+    a: Sequence[Sequence[Number]],
+    b: Sequence[Sequence[Number]],
+    policy: NumericPolicy,
+) -> bool:
+    if len(a) != len(b):
+        return False
+    for row_a, row_b in zip(a, b):
+        if len(row_a) != len(row_b):
+            return False
+        for x, y in zip(row_a, row_b):
+            if not approx_equal_number(x, y, policy):
+                return False
+    return True
+
+
+def max_abs_diff(a: Sequence[Sequence[Number]], b: Sequence[Sequence[Number]]) -> float:
+    """Return the maximum absolute elementwise difference between matrices."""
+
+    maximum = 0.0
+    for row_a, row_b in zip(a, b):
+        for x, y in zip(row_a, row_b):
+            diff = abs(x - y)
+            if diff > maximum:
+                maximum = diff
+    return maximum

--- a/anyon_condense/core/consistency/pentagon.py
+++ b/anyon_condense/core/consistency/pentagon.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Tuple, Union
+
+from anyon_condense.core.consistency.numcheck import approx_equal_number
+from anyon_condense.scalars.numeric_policy import NumericPolicy
+
+Number = Union[int, float, complex]
+
+
+def check_pentagon_equations(
+    equations: Iterable[Tuple[Number, Number]], policy: NumericPolicy
+) -> Dict[str, Any]:
+    total = 0
+    failed = 0
+    for lhs, rhs in equations:
+        total += 1
+        if not approx_equal_number(lhs, rhs, policy):
+            failed += 1
+    return {"status": failed == 0, "failed": failed, "total": total}

--- a/tests/unit/test_consistency_numeric_policy.py
+++ b/tests/unit/test_consistency_numeric_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from anyon_condense.core.consistency.hexagon import check_hexagon_equations
+from anyon_condense.core.consistency.modular import check_modular_relations
+from anyon_condense.core.consistency.numcheck import (
+    approx_equal_matrices,
+    approx_equal_number,
+    max_abs_diff,
+)
+from anyon_condense.core.consistency.pentagon import check_pentagon_equations
+from anyon_condense.scalars.numeric_policy import NumericPolicy
+
+
+def toric_st():
+    s = [
+        [0.5, 0.5, 0.5, 0.5],
+        [0.5, 0.5, -0.5, -0.5],
+        [0.5, -0.5, 0.5, -0.5],
+        [0.5, -0.5, -0.5, 0.5],
+    ]
+    t = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, -1.0],
+    ]
+    return s, t
+
+
+def test_numcheck_scalar_and_matrix():
+    policy = NumericPolicy(tol_abs=1e-10, tol_rel=1e-10)
+    assert approx_equal_number(1.0, 1.0 + 5e-11, policy)
+    assert not approx_equal_number(1.0, 1.0 + 5e-7, policy)
+
+    a = [[1.0, 2.0], [3.0, 4.0]]
+    b = [[1.0 + 1e-12, 2.0 - 1e-12], [3.0, 4.0 + 5e-12]]
+    assert approx_equal_matrices(a, b, policy)
+    assert max_abs_diff(a, b) >= 0.0
+
+
+def test_modular_relations_noise_sensitivity():
+    policy = NumericPolicy(tol_abs=1e-10, tol_rel=1e-10)
+    s, t = toric_st()
+
+    report_clean = check_modular_relations(s, t, policy)
+    assert report_clean["status"] is True
+    assert report_clean["max_err_st3_s2"] <= 1e-12
+    assert report_clean["max_err_s4_i"] <= 1e-12
+
+    noisy = [
+        [entry + (1e-12 if (i + j) % 2 == 0 else -1e-12) for j, entry in enumerate(row)]
+        for i, row in enumerate(s)
+    ]
+    report_noisy = check_modular_relations(noisy, t, policy)
+    assert report_noisy["status"] is True
+
+    coarse = [
+        [entry + (1e-6 if (i + j) % 2 == 0 else -1e-6) for j, entry in enumerate(row)]
+        for i, row in enumerate(s)
+    ]
+    report_fail = check_modular_relations(coarse, t, policy)
+    assert report_fail["status"] is False
+
+    loose_policy = NumericPolicy(tol_abs=1e-5, tol_rel=1e-5)
+    report_pass = check_modular_relations(coarse, t, loose_policy)
+    assert report_pass["status"] is True
+
+
+def test_pentagon_and_hexagon_wrappers():
+    policy = NumericPolicy()
+    equations = [
+        (1.0, 1.0 + 5e-12),
+        (2.0, 2.0 - 5e-12),
+        (1.0, 1.05),
+    ]
+    pentagon_report = check_pentagon_equations(equations, policy)
+    hexagon_report = check_hexagon_equations(equations, policy)
+
+    assert pentagon_report["status"] is False
+    assert pentagon_report["failed"] == 1
+    assert pentagon_report["total"] == 3
+
+    assert hexagon_report["status"] is False
+    assert hexagon_report["failed"] == 1
+    assert hexagon_report["total"] == 3


### PR DESCRIPTION
### Summary
- Add core/consistency/numcheck.py with scalar/matrix approx_equal helpers.
- Update modular/pentagon/hexagon checks to accept `policy: NumericPolicy` and use mixed tolerances.
- Add unit tests: Toric passes at 1e-10; ±1e-12 noise passes; 1e-6 fails (then passes with relaxed policy).

### Verification
- pytest: all green
- ruff/mypy/pre-commit: clean
- CLI demo available: `ac num show-policy`, `ac num dump --in ...`
